### PR TITLE
remove the pypi not available note. fix core init arg name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,8 +42,6 @@ image from the assets folder in the PCB's GitHub repo.
 `Purchase one from the Adafruit shop <http://www.adafruit.com/products/>`_
 Installing from PyPI
 =====================
-.. note:: This library is not available on PyPI yet. Install documentation is included
-   as a standard element. Stay tuned for PyPI availability!
 
 .. todo:: Remove the above note if PyPI version is/will be available at time of release.
 

--- a/adafruit_acep7in.py
+++ b/adafruit_acep7in.py
@@ -84,5 +84,5 @@ class ACeP7In(displayio.EPaperDisplay):
             busy_state=False,
             write_black_ram_command=0x10,
             refresh_display_command=b"\x12\x01\x00",
-            acep=True
+            advanced_color_epaper=True
         )


### PR DESCRIPTION
This change removes the 'not available on pypi' note from the readme as noted in #1 . (As-is this will release to pypi when a release is made on github if everything goes correctly I believe.)

I've also changed the name of the argument passed to the core `EPaperDisplay` init function to match the name that was landed upon in the core: https://github.com/adafruit/circuitpython/blob/dec3cfc95501bc604e564007bb22d0ca3f28c95a/shared-bindings/displayio/EPaperDisplay.c#L122

I am guessing this abbreviated name was used during development at some point but changed before being finalized and released.